### PR TITLE
[CU-86et87n3r] endpoint to get versions by id

### DIFF
--- a/App/Modules/Cyan/API/V1/Controllers/PluginController.cs
+++ b/App/Modules/Cyan/API/V1/Controllers/PluginController.cs
@@ -353,4 +353,14 @@ public class PluginController(
       new EntityNotFound("Plugin not found", typeof(PluginPrincipal), $"{username}/{req.Name}")
     );
   }
+
+  [HttpGet("versions/{versionId:guid}")]
+  public async Task<ActionResult<PluginVersionResp>> GetVersionById(Guid versionId)
+  {
+    var plugin = await service.GetVersionById(versionId).Then(x => x?.ToResp(), Errors.MapNone);
+    return this.ReturnNullableResult(
+      plugin,
+      new EntityNotFound("Plugin version not found", typeof(PluginVersion), versionId.ToString())
+    );
+  }
 }

--- a/App/Modules/Cyan/API/V1/Controllers/ProcessorController.cs
+++ b/App/Modules/Cyan/API/V1/Controllers/ProcessorController.cs
@@ -389,4 +389,18 @@ public class ProcessorController(
       )
     );
   }
+
+  [HttpGet("versions/{versionId:guid}")]
+  public async Task<ActionResult<ProcessorVersionResp>> GetVersionById(Guid versionId)
+  {
+    var processor = await service.GetVersionById(versionId).Then(x => x?.ToResp(), Errors.MapNone);
+    return this.ReturnNullableResult(
+      processor,
+      new EntityNotFound(
+        "Processor version not found",
+        typeof(ProcessorVersion),
+        versionId.ToString()
+      )
+    );
+  }
 }

--- a/App/Modules/Cyan/API/V1/Controllers/TemplateController.cs
+++ b/App/Modules/Cyan/API/V1/Controllers/TemplateController.cs
@@ -400,4 +400,18 @@ public class TemplateController(
       new EntityNotFound("Template not found", typeof(TemplatePrincipal), $"{username}/{req.Name}")
     );
   }
+
+  [HttpGet("versions/{versionId:guid}")]
+  public async Task<ActionResult<TemplateVersionResp>> GetVersionById(Guid versionId)
+  {
+    var template = await service.GetVersionById(versionId).Then(x => x?.ToResp(), Errors.MapAll);
+    return this.ReturnNullableResult(
+      template,
+      new EntityNotFound(
+        "Template version not found",
+        typeof(TemplateVersion),
+        versionId.ToString()
+      )
+    );
+  }
 }

--- a/App/Modules/Cyan/Data/Repositories/PluginRepository.cs
+++ b/App/Modules/Cyan/Data/Repositories/PluginRepository.cs
@@ -586,6 +586,25 @@ public class PluginRepository(MainDbContext db, ILogger<PluginRepository> logger
     }
   }
 
+  public async Task<Result<PluginVersion?>> GetVersionById(Guid versionId)
+  {
+    try
+    {
+      logger.LogInformation("Getting plugin version with Id '{VersionId}'", versionId);
+      var version = await db
+        .PluginVersions.Where(x => x.Id == versionId)
+        .Include(x => x.Plugin)
+        .FirstOrDefaultAsync();
+
+      return version?.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed getting plugin version with Id '{VersionId}'", versionId);
+      return e;
+    }
+  }
+
   public async Task<Result<PluginVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/App/Modules/Cyan/Data/Repositories/ProcessorRepository.cs
+++ b/App/Modules/Cyan/Data/Repositories/ProcessorRepository.cs
@@ -614,6 +614,25 @@ public class ProcessorRepository(MainDbContext db, ILogger<ProcessorRepository> 
     }
   }
 
+  public async Task<Result<ProcessorVersion?>> GetVersionById(Guid versionId)
+  {
+    try
+    {
+      logger.LogInformation("Getting processor version with Id '{VersionId}'", versionId);
+      var version = await db
+        .ProcessorVersions.Where(x => x.Id == versionId)
+        .Include(x => x.Processor)
+        .FirstOrDefaultAsync();
+
+      return version?.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed getting processor version with Id '{VersionId}'", versionId);
+      return e;
+    }
+  }
+
   public async Task<Result<ProcessorVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/App/Modules/Cyan/Data/Repositories/TemplateRepository.cs
+++ b/App/Modules/Cyan/Data/Repositories/TemplateRepository.cs
@@ -550,6 +550,30 @@ public class TemplateRepository(MainDbContext db, ILogger<TemplateRepository> lo
     }
   }
 
+  public async Task<Result<TemplateVersion?>> GetVersionById(Guid versionId)
+  {
+    try
+    {
+      logger.LogInformation("Getting template version with Id '{VersionId}'", versionId);
+      var version = await db
+        .TemplateVersions.Where(x => x.Id == versionId)
+        .Include(x => x.Template)
+        .Include(x => x.Processors)
+        .ThenInclude(x => x.Processor)
+        .Include(x => x.Plugins)
+        .ThenInclude(x => x.Plugin)
+        .Include(x => x.TemplateRefs)
+        .ThenInclude(x => x.TemplateRef)
+        .FirstOrDefaultAsync();
+      return version?.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed getting template version with Id '{VersionId}'", versionId);
+      return e;
+    }
+  }
+
   public async Task<Result<TemplateVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Repository/IPluginRepository.cs
+++ b/Domain/Repository/IPluginRepository.cs
@@ -45,6 +45,8 @@ public interface IPluginRepository
 
   Task<Result<PluginVersion?>> GetVersion(string userId, Guid id, ulong version);
 
+  Task<Result<PluginVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<PluginVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Repository/IProcessorRepository.cs
+++ b/Domain/Repository/IProcessorRepository.cs
@@ -53,6 +53,8 @@ public interface IProcessorRepository
 
   Task<Result<ProcessorVersion?>> GetVersion(string userId, Guid id, ulong version);
 
+  Task<Result<ProcessorVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<ProcessorVersionPrincipal?>> CreateVersion(
     string userId,
     string name,

--- a/Domain/Repository/ITemplateRepository.cs
+++ b/Domain/Repository/ITemplateRepository.cs
@@ -48,6 +48,8 @@ public interface ITemplateRepository
   Task<Result<TemplateVersion?>> GetVersion(string userId, Guid id, ulong version);
   Task<Result<TemplateVersion?>> GetVersion(string username, string name);
 
+  Task<Result<TemplateVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<TemplateVersionPrincipal?>> CreateVersion(
     string userId,
     string name,

--- a/Domain/Service/IPluginService.cs
+++ b/Domain/Service/IPluginService.cs
@@ -43,6 +43,8 @@ public interface IPluginService
 
   Task<Result<PluginVersion?>> GetVersion(string userId, Guid id, ulong version);
 
+  Task<Result<PluginVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<PluginVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Service/IProcessorService.cs
+++ b/Domain/Service/IProcessorService.cs
@@ -51,6 +51,8 @@ public interface IProcessorService
   Task<Result<ProcessorVersion?>> GetVersion(string username, string name, bool bumpDownload);
   Task<Result<ProcessorVersion?>> GetVersion(string userId, Guid id, ulong version);
 
+  Task<Result<ProcessorVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<ProcessorVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Service/ITemplateService.cs
+++ b/Domain/Service/ITemplateService.cs
@@ -48,6 +48,8 @@ public interface ITemplateService
 
   Task<Result<TemplateVersion?>> GetVersion(string userId, Guid id, ulong version);
 
+  Task<Result<TemplateVersion?>> GetVersionById(Guid versionId);
+
   Task<Result<TemplateVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Service/PluginService.cs
+++ b/Domain/Service/PluginService.cs
@@ -146,6 +146,11 @@ public class PluginService(
     return repo.GetVersion(userId, id, version);
   }
 
+  public Task<Result<PluginVersion?>> GetVersionById(Guid versionId)
+  {
+    return repo.GetVersionById(versionId);
+  }
+
   public Task<Result<PluginVersionPrincipal?>> CreateVersion(
     string userId,
     string name,

--- a/Domain/Service/ProcessorService.cs
+++ b/Domain/Service/ProcessorService.cs
@@ -152,6 +152,11 @@ public class ProcessorService(
     return repo.GetVersion(userId, id, version);
   }
 
+  public Task<Result<ProcessorVersion?>> GetVersionById(Guid versionId)
+  {
+    return repo.GetVersionById(versionId);
+  }
+
   public Task<Result<ProcessorVersionPrincipal?>> CreateVersion(
     string username,
     string name,

--- a/Domain/Service/TemplateService.cs
+++ b/Domain/Service/TemplateService.cs
@@ -152,6 +152,11 @@ public class TemplateService(
     return repo.GetVersion(userId, id, version);
   }
 
+  public Task<Result<TemplateVersion?>> GetVersionById(Guid versionId)
+  {
+    return repo.GetVersionById(versionId);
+  }
+
   public async Task<Result<TemplateVersionPrincipal?>> CreateVersion(
     string userId,
     string name,


### PR DESCRIPTION
- added GetVersionById method to IPluginRepository
- added GetVersionById method to IProcessorRepository
- added GetVersionById method to ITemplateRepository
- added GetVersionById method to IPluginService
- added GetVersionById method to IProcessorService
- added GetVersionById method to ITemplateService

this commit introduces a new endpoint to retrieve versions by their unique identifier, enhancing the functionality of the version management system.