### PR TITLE
feat(docker): allow dots in docker tags

### DIFF
--- a/App/Utility/ValidationUtility.cs
+++ b/App/Utility/ValidationUtility.cs
@@ -70,9 +70,9 @@ public static class ValidationUtility
     return ruleBuilder
       .Length(1, 32)
       .WithMessage("Docker tag must be between 1 and 32 characters")
-      .Matches(@"^[a-z0-9](\-?[a-z0-9]+)*$")
+      .Matches(@"^[a-z0-9](\.?\-?[a-z0-9]+)*$")
       .WithMessage(
-        "Docker tag can only contain alphanumeric characters and dashes, and cannot star or end with dash"
+        "Docker tag can only contain alphanumeric characters, dots dashes, and cannot start or end with dash"
       );
   }
 


### PR DESCRIPTION
- updated regex to allow dots in docker tags
- modified error message to reflect new validation rules

this change enhances the flexibility of docker tags by allowing dots, which are commonly used in versioning and naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tags can now include dots (.) in addition to letters, numbers, and dashes, enabling more flexible naming.
* **Documentation**
  * Validation message updated to clearly state allowed characters and that tags cannot start or end with a dash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->